### PR TITLE
OPS-4912 Add CRI parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ RUN apk add --no-cache --update --virtual .build-deps build-base ruby-dev \
         && gem install fluent-plugin-ec2-metadata -v 0.1.3 \
         && gem install fluent-plugin-rewrite-tag-filter -v 2.4.0 \
         && gem install fluent-plugin-sumologic_output -v 1.7.2 \
+        && gem install fluent-plugin-parser-cri -v 0.1.1 \
         && gem sources --clear-all \
         && apk del .build-deps \
         && rm -rf /home/fluent/.gem/ruby/*/cache/*.gem
 
-COPY --chown=fluentd:fluentd fluent.conf /fluentd/etc/fluent.conf
+COPY --chown=fluent:fluent fluent.conf /fluentd/etc/fluent.conf


### PR DESCRIPTION
- fix wrong user name in Dockerfile

The wrong user name might be related to a change in the base image, the right user is "fluent", not "fluentd".

I've pushed an image built with this Dockerfile at 979633842206.dkr.ecr.eu-west-1.amazonaws.com/fluentd:v1.13-1-cri